### PR TITLE
Add LCD 8080 bus decoder

### DIFF
--- a/runtime/decoders/LCD8080/__init__.py
+++ b/runtime/decoders/LCD8080/__init__.py
@@ -1,0 +1,9 @@
+'''
+Intel 8080.
+
+In addition to the 8-bit data bus, this decoder requires the input signals
+A0/DC (Command/Data Select), /WR (Write) and optionally /CS (Chip Select) to do its work. An explicit
+clock signal is not required.
+'''
+
+from .pd import Decoder

--- a/runtime/decoders/LCD8080/pd.py
+++ b/runtime/decoders/LCD8080/pd.py
@@ -1,0 +1,86 @@
+import sigrokdecode as srd
+
+class Ann:
+    CMD, DATA = range(2)
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'lcd8080'
+    name = 'LCD8080'
+    longname = '8080 Parallel LCD Interface'
+    desc = 'Decode CMD/DATA writes on 8080 8-bit parallel LCD'
+    license = 'gplv3+'
+    inputs = ['logic']
+    outputs = []
+    tags = ['Display']
+    options = (
+        {'id': 'a0dc_polarity', 'desc': 'Data Polarity (Low = Data, High = Data)',
+            'default': 'low', 'values': ('low', 'high')},
+        {'id': 'offset_samples', 'desc': 'Delay after WR falling edge (samples)', 'default': 0},
+    )
+    channels = tuple({
+            'id': 'd%d' % i,
+            'name': 'D%d' % i,
+            'desc': 'Data bus line %d' % i
+            } for i in range(8)
+    ) + (
+        {'id': 'wr', 'name': '/WR', 'desc': 'Write strobe (active low)'},
+        {'id': 'a0dc', 'name': 'A0/DC', 'desc': 'Command/Data select'},
+    )
+    optional_channels = (
+        {'id': 'cs', 'name': '/CS', 'desc': 'Chip Select (active low)'},
+    )
+    annotations = (
+        ('cmd', 'Command'),
+        ('data', 'Data'),
+    )
+    annotation_rows = (
+        ('cmd_', 'Command', (Ann.CMD,)),
+        ('data_', 'Data', (Ann.DATA,)),
+    )
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.prev_wr = 1
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+
+    def decode(self):
+        while True:
+            pins = self.wait()
+            curr_wr = pins[8]
+
+            if self.prev_wr == 1 and curr_wr == 0:
+                count = 0
+
+                cs_connected = len(pins) > 10
+                if cs_connected and pins[10] != 0:
+                    self.prev_wr = curr_wr
+                    continue
+                
+                while count < self.options['offset_samples']:
+                    pins = self.wait()
+                    count += 1
+
+                # After N sample steps, sample data bus
+                data_bits = pins[0:8]
+                if 0xFF in data_bits:
+                    continue  # Skip if any undefined bits
+
+                value = 0
+                for i, bit in enumerate(data_bits):
+                    value |= (bit << i)
+
+                a0_dc = pins[9]
+                if self.options['a0dc_polarity'] == 'low': 
+                    ann_id = Ann.CMD if a0_dc else Ann.DATA
+                else:
+                    ann_id = Ann.DATA if a0_dc else Ann.CMD
+                label = '0x%02X' % value
+
+                self.put(self.samplenum, self.samplenum, self.out_ann, [ann_id, [label]])
+
+            self.prev_wr = curr_wr

--- a/runtime/decoders/LCD8080/placeholder
+++ b/runtime/decoders/LCD8080/placeholder
@@ -1,1 +1,0 @@
-new folder

--- a/runtime/decoders/LCD8080/placeholder
+++ b/runtime/decoders/LCD8080/placeholder
@@ -1,0 +1,1 @@
+new folder


### PR DESCRIPTION
![working example](https://github.com/user-attachments/assets/3eecd8a4-291c-49cd-9b15-df5c1fe9ad48)
I have created a comprehensive 8 bit bus decoder for the ATK-Logic platform which provides the ability to:
- Set channels D0 - D7
- Set Write Enable channel
- Set A0/DC channel
- Optionally set channel for Chip Select filtering
- Set Command/Data Polarity (High = Data ect)
- Ability to optionally set a delay after falling edge for cleaner reads
![protocol settings example](https://github.com/user-attachments/assets/ce6a881a-27b0-4994-b55d-ae16c2f9ee9a)

